### PR TITLE
Adhereing to tenancy access roles in reporting CRUD operations

### DIFF
--- a/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportActionType.kt
+++ b/reports-scheduler/src/main/kotlin/org/opensearch/reportsscheduler/model/ReportActionType.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.reportsscheduler.model
+
+enum class ReportActionType {
+    CREATE, READ, UPDATE, DELETE
+}


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
Adhereing to tenancy access roles in reporting CRUD operations

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
