### PR TITLE
Fix report click for firefox

### DIFF
--- a/dashboards-reports/public/components/main/main_utils.tsx
+++ b/dashboards-reports/public/components/main/main_utils.tsx
@@ -181,7 +181,7 @@ export const generateReportFromDefinitionId = async (
         `${response.queryUrl}&${GENERATE_REPORT_PARAM}=${response.reportId}`;
       a.target = '_blank';
       a.rel = 'noreferrer';
-      a.click();
+      a.dispatchEvent(new MouseEvent(`click`, {bubbles: true, cancelable: true, view: window}));
       status = true;
     })
     .catch((error) => {
@@ -225,7 +225,7 @@ export const generateReportById = async (
         `${response.queryUrl}&${GENERATE_REPORT_PARAM}=${reportId}`;
       a.target = '_blank';
       a.rel = 'noreferrer';
-      a.click();
+      a.dispatchEvent(new MouseEvent(`click`, {bubbles: true, cancelable: true, view: window}));
     })
     .catch((error) => {
       console.log('error on generating report by id:', error);


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description
`link.click` is not supported by firefox. Replacing it with `link.dispatchEvent`

### Issues Resolved
#577

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
