### PR TITLE
Revert "Bump version 2.3.1" in aos-2.3.0.0 

### DIFF
--- a/.github/workflows/dashboards-reports-test-and-build-workflow.yml
+++ b/.github/workflows/dashboards-reports-test-and-build-workflow.yml
@@ -6,7 +6,7 @@ env:
   PLUGIN_NAME: reportsDashboards
   ARTIFACT_NAME: reports-dashboards
   OPENSEARCH_VERSION: 'main'
-  OPENSEARCH_PLUGIN_VERSION: 2.3.1.0
+  OPENSEARCH_PLUGIN_VERSION: 2.3.0.0
 
 jobs:
   build:

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)
-          version: 2.3.1.0
+          version: 2.3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dashboards-reports/opensearch_dashboards.json
+++ b/dashboards-reports/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "reportsDashboards",
-  "version": "2.3.1.0",
-  "opensearchDashboardsVersion": "2.3.1",
+  "version": "2.3.0.0",
+  "opensearchDashboardsVersion": "2.3.0",
   "requiredPlugins": ["navigation", "data", "opensearchDashboardsUtils"],
   "optionalPlugins": ["share"],
   "server": true,

--- a/dashboards-reports/package.json
+++ b/dashboards-reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-dashboards",
-  "version": "2.3.1.0",
+  "version": "2.3.0.0",
   "description": "OpenSearch Dashboards Reports Plugin",
   "license": "Apache-2.0",
   "main": "index.ts",

--- a/reports-scheduler/build.gradle
+++ b/reports-scheduler/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         opensearch_group = "org.opensearch"
 
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.3.1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.3.0-SNAPSHOT")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')


### PR DESCRIPTION
This reverts commit 9ca29ff1527d3a50b7861510989dd7bba94861cc.

Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
Fixing version for aos-2.3.0.0 branch

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
