### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,12 @@
-## Maintainers
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
 | Maintainer             | GitHub ID                                         | Affiliation |
-|------------------------|---------------------------------------------------|-------------|
+| ---------------------- | ------------------------------------------------- | ----------- |
 | Anantha Krishna Bhatta | [akbhatta](https://github.com/akbhatta)           | Amazon      |
 | David Cui              | [davidcui-amzn](https://github.com/davidcui-amzn) | Amazon      |
 | Joshua Li              | [joshuali925](https://github.com/joshuali925)     | Amazon      |
 | Zhongnan Su            | [zhongnansu](https://github.com/zhongnansu)       | Amazon      |
-
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.