### PR TITLE
Remove guava from dependencies to fix jar hell issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     implementation "${group}:common-utils:${common_utils_version}"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation "org.json:json:20180813"
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
     // json-base is transitive dependencies by json-flattener
@@ -179,7 +178,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "org.mockito:mockito-core:4.7.0"
+    testImplementation "org.mockito:mockito-core:5.1.0"
     testImplementation "org.mockito:mockito-junit-jupiter:4.7.0"
     testImplementation 'com.google.code.gson:gson:2.8.9'
 


### PR DESCRIPTION
Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
- Changed mockito-core version to 5.1.0 to resolve conflicts
```
 > Conflict(s) found for the following module(s):
14 actionable tasks: 14 executed
          - org.mockito:mockito-core between versions 5.1.0 and 4.7.0
        Run with:
            --scan or
            :dependencyInsight --configuration testCompileClasspath --dependency org.mockito:mockito-core
```

- Removed guava from dependencies to resolve
```
Caused by: java.lang.IllegalStateException: jar hell!
class: com.google.common.annotations.Beta
jar1: /tmp/tmpincskegu/opensearch-3.0.0/plugins/.installing-14976970994818525932/guava-31.0.1-jre.jar
jar2: /tmp/tmpincskegu/opensearch-3.0.0/plugins/opensearch-job-scheduler/guava-31.0.1-jre.jar
	at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
```


### Issues Resolved
https://github.com/opensearch-project/reporting/issues/637

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
