### PR TITLE
fix maven publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - main
-      - 1.*
-      - 2.*
+      - 1.3
+      - 2.x
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,11 +3,10 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-    branches: [
+    branches:
       - main
       - 1.*
       - 2.*
-    ]
 
 jobs:
   build-and-publish-snapshots:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 1.3
+      - '1.3'
       - 2.x
 
 jobs:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
   push:
     branches: [
-      main
-        1.*
-        2.*
+      - main
+      - 1.*
+      - 2.*
     ]
 
 jobs:


### PR DESCRIPTION
### Description
github maven publish workflow is not publishing currently, this fixes a syntax error to start that process

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
