### PR TITLE
Bump mockito-core version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "org.mockito:mockito-core:5.1.0"
+    testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "org.mockito:mockito-junit-jupiter:4.7.0"
     testImplementation 'com.google.code.gson:gson:2.8.9'
 


### PR DESCRIPTION
### Description
- Added ${versions.mockito} to fetch mockito version from Opensearch

### Issues Resolved
Resolve below build error
```
* What went wrong:
Execution failed for task ':compileTestKotlin'.
> Error while evaluating property 'filteredArgumentsMap' of task ':compileTestKotlin'
   > Could not resolve all dependencies for configuration ':testCompileClasspath'.
      > Conflict(s) found for the following module(s):
          - org.mockito:mockito-core between versions 5.2.0 and 5.1.0
        Run with:
            --scan or
            :dependencyInsight --configuration testCompileClasspath --dependency org.mockito:mockito-core
        to get more insight on how to solve the conflict.
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
