### PR TITLE
[Backport 1.3] Update json version to 20230227

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     compile "${group}:common-utils:${common_utils_version}"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
     compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
-    compile "org.json:json:20180813"
+    compile "org.json:json:20230227"
     compile group: 'com.github.wnameless', name: 'json-flattener', version: '0.1.0'
     implementation 'org.jsoup:jsoup:1.15.3'
 


### PR DESCRIPTION
### Description
- Backport Update json version to 20230227  #692 to main

### Issues Resolved
[CVE-2022-45688](https://github.com/advisories/GHSA-3vqj-43w4-2q58)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
