### PR TITLE
Fix bwc job-scheduler and reporting artifact URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,8 +329,8 @@ String baseVersion = "2.8.0"
 String bwcVersion = baseVersion + ".0"
 String baseName = "reportsSchedulerBwcCluster"
 String bwcFilePath = "src/test/resources/bwc"
-String bwcJobSchedulerURL = "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=$bwcVersion-SNAPSHOT&p=zip"
-String bwcReportsSchedulerURL = "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=$bwcVersion-SNAPSHOT&p=zip"
+String bwcJobSchedulerURL = "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-job-scheduler&v=$bwcVersion-SNAPSHOT&p=zip"
+String bwcReportsSchedulerURL = "https://aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a=opensearch-reports-scheduler&v=$bwcVersion-SNAPSHOT&p=zip"
 
 2.times {i ->
     testClusters {


### PR DESCRIPTION
### Description
Currently bwc still fails because job-scheduler still has guava which causes jar hell. Reporting fixed it in https://github.com/opensearch-project/reporting/pull/638

https://github.com/opensearch-project/job-scheduler/blob/946b0cafecda71bd5b19220a67a1e61af6081382/build.gradle#L155

```
> Task :reportsSchedulerBwcCluster#oldVersionClusterTask1
Exec output and error:
| Output for ./bin/opensearch-plugin:-> Installing file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/job-scheduler/2.8.0.0/opensearch-job-scheduler-2.8.0.0.zip
| -> Downloading file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/job-scheduler/2.8.0.0/opensearch-job-scheduler-2.8.0.0.zip
| -> Installed opensearch-job-scheduler with folder name opensearch-job-scheduler
| -> Installing file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/reports-scheduler/2.8.0.0/opensearch-reports-scheduler-2.8.0.0.zip
| -> Downloading file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/reports-scheduler/2.8.0.0/opensearch-reports-scheduler-2.8.0.0.zip
| -> Failed installing file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/reports-scheduler/2.8.0.0/opensearch-reports-scheduler-2.8.0.0.zip
| -> Rolling back opensearch-job-scheduler
| -> Rolled back opensearch-job-scheduler
| -> Rolling back file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/reports-scheduler/2.8.0.0/opensearch-reports-scheduler-2.8.0.0.zip
| -> Rolled back file:/local/home/user/projects/os-3.0/repos/reporting/src/test/resources/bwc/reports-scheduler/2.8.0.0/opensearch-reports-scheduler-2.8.0.0.zip
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-reports-scheduler due to jar hell
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:681)
|       at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:862)
|       at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:830)
|       at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:875)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:276)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:250)
|       at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.Command.main(Command.java:101)
|       at org.opensearch.plugins.PluginCli.main(PluginCli.java:60)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: com.google.common.annotations.Beta
| jar1: /local/home/user/projects/os-3.0/repos/reporting/build/testclusters/reportsSchedulerBwcCluster1-0/distro/2.8.0-ARCHIVE/plugins/.installing-18383808834074508769/guava-31.0.1-jre.jar
| jar2: /local/home/user/projects/os-3.0/repos/reporting/build/testclusters/reportsSchedulerBwcCluster1-0/distro/2.8.0-ARCHIVE/plugins/opensearch-job-scheduler/guava-31.0.1-jre.jar
|       at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
|       at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:667)
|       ... 11 more
```

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
