### PR TITLE
Removing guava dependency to fix jarhell

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9"
     implementation "${group}:common-utils:${common_utils_version}"
     compileOnly "${group}:opensearch-job-scheduler-spi:${job_scheduler_version}"
-    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation "org.json:json:20230227"
     implementation group: 'com.github.wnameless.json', name: 'json-flattener', version: '0.15.1'
     // json-base, jackson-databind, jackson-annotations are transitive dependencies by json-flattener

--- a/release-notes/opensearch-reporting.release-notes-2.8.0.0.md
+++ b/release-notes/opensearch-reporting.release-notes-2.8.0.0.md
@@ -5,6 +5,7 @@ Compatible with OpenSearch 2.8.0
 ### Bug Fixes
 * Update json version to 20230227 ([#692](https://github.com/opensearch-project/reporting/pull/692))
 * Update Gradle Wrapper to 7.6.1 ([#695](https://github.com/opensearch-project/reporting/pull/695))
+* Removing guava dependency to fix jarhell ([#709](https://github.com/opensearch-project/reporting/pull/709))
 
 ### Maintenance
 * Increment version to 2.8.0-SNAPSHOT ([#688](https://github.com/opensearch-project/reporting/pull/688))


### PR DESCRIPTION
### Description
Removing guava dependency to fix jarhell

### Issues Resolved
```
> Task :integTest FAILED
Exec output and error:
| Output for ./bin/opensearch-plugin:warning: no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release
| -> Installing file:/Users/sgguruda/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/opensearch-job-scheduler/2.8.0.0-SNAPSHOT/8e21a3baa1d3c5663c7554b27e81809cb33132dd/opensearch-job-scheduler-2.8.0.0-SNAPSHOT.zip
| -> Downloading file:/Users/sgguruda/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/opensearch-job-scheduler/2.8.0.0-SNAPSHOT/8e21a3baa1d3c5663c7554b27e81809cb33132dd/opensearch-job-scheduler-2.8.0.0-SNAPSHOT.zip
| -> Installed opensearch-job-scheduler with folder name opensearch-job-scheduler
| -> Installing file:/Users/sgguruda/work/git_codebase/temp/reporting/build/distributions/opensearch-reports-scheduler-2.8.0.0-SNAPSHOT.zip
| -> Downloading file:/Users/sgguruda/work/git_codebase/temp/reporting/build/distributions/opensearch-reports-scheduler-2.8.0.0-SNAPSHOT.zip
| -> Failed installing file:/Users/sgguruda/work/git_codebase/temp/reporting/build/distributions/opensearch-reports-scheduler-2.8.0.0-SNAPSHOT.zip
| -> Rolling back opensearch-job-scheduler
| -> Rolled back opensearch-job-scheduler
| -> Rolling back file:/Users/sgguruda/work/git_codebase/temp/reporting/build/distributions/opensearch-reports-scheduler-2.8.0.0-SNAPSHOT.zip
| -> Rolled back file:/Users/sgguruda/work/git_codebase/temp/reporting/build/distributions/opensearch-reports-scheduler-2.8.0.0-SNAPSHOT.zip
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-reports-scheduler due to jar hell
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:681)
|       at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:862)
|       at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:830)
|       at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:875)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:276)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:250)
|       at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.Command.main(Command.java:101)
|       at org.opensearch.plugins.PluginCli.main(PluginCli.java:60)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: com.google.common.annotations.Beta
| jar1: /Users/sgguruda/work/git_codebase/temp/reporting/build/testclusters/integTest-0/distro/2.8.0-INTEG_TEST/plugins/.installing-5340402862772191192/guava-31.0.1-jre.jar
| jar2: /Users/sgguruda/work/git_codebase/temp/reporting/build/testclusters/integTest-0/distro/2.8.0-INTEG_TEST/plugins/opensearch-job-scheduler/guava-31.0.1-jre.jar
|       at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
|       at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:667)
|       ... 11 more
```

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
