### PR TITLE
[Security] Bumping ktlint to 0.47.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,7 @@ configurations.all {
         force "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4"
         force "org.yaml:snakeyaml:2.0"
+		force "org.slf4j:slf4j-api:2.0.7"
     }
 }
 
@@ -198,7 +199,7 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:${versions.mockito}"
     testImplementation 'com.google.code.gson:gson:2.8.9'
 
-    ktlint "com.pinterest:ktlint:0.45.1"
+    ktlint "com.pinterest:ktlint:0.47.1"
 }
 
 javadoc.enabled = false // turn off javadoc as it barfs on Kotlin code

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,8 @@ configurations.all {
         force "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4"
         force "org.yaml:snakeyaml:2.0"
 		force "org.slf4j:slf4j-api:2.0.7"
+		force "ch.qos.logback:logback-classic:1.3.14"
+		force "ch.qos.logback:logback-core:1.3.14"
     }
 }
 

--- a/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/OnDemandReportRestHandler.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/resthandler/OnDemandReportRestHandler.kt
@@ -109,7 +109,8 @@ internal class OnDemandReportRestHandler : PluginBaseHandler() {
                 client.execute(
                     OnDemandReportCreateAction.ACTION_TYPE,
                     OnDemandReportCreateRequest.parse(
-                        request.contentParserNextToken(), request.param(REPORT_DEFINITION_ID_FIELD)
+                        request.contentParserNextToken(),
+                        request.param(REPORT_DEFINITION_ID_FIELD)
                     ),
                     RestResponseToXContentListener(it)
                 )

--- a/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/settings/PluginSettings.kt
@@ -117,26 +117,31 @@ internal object PluginSettings {
         OPERATION_TIMEOUT_MS_KEY,
         defaultSettings[OPERATION_TIMEOUT_MS_KEY]!!.toLong(),
         MINIMUM_OPERATION_TIMEOUT_MS,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val DEFAULT_ITEMS_QUERY_COUNT: Setting<Int> = Setting.intSetting(
         DEFAULT_ITEMS_QUERY_COUNT_KEY,
         defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
         MINIMUM_ITEMS_QUERY_COUNT,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     private val LEGACY_FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
         LEGACY_FILTER_BY_BACKEND_ROLES_KEY,
         false,
-        NodeScope, Dynamic, Setting.Property.Deprecated
+        NodeScope,
+        Dynamic,
+        Setting.Property.Deprecated
     )
 
     private val FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
         FILTER_BY_BACKEND_ROLES_KEY,
         LEGACY_FILTER_BY_BACKEND_ROLES,
-        NodeScope, Dynamic
+        NodeScope,
+        Dynamic
     )
 
     /**

--- a/src/test/kotlin/org/opensearch/integTest/PluginRestTestCase.kt
+++ b/src/test/kotlin/org/opensearch/integTest/PluginRestTestCase.kt
@@ -63,7 +63,8 @@ abstract class PluginRestTestCase : OpenSearchRestTestCase() {
         val response = client().performRequest(Request("GET", "/_cat/indices?format=json&expand_wildcards=all"))
         val xContentType = MediaType.fromMediaType(response.entity.contentType)
         xContentType.xContent().createParser(
-            NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            NamedXContentRegistry.EMPTY,
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
             response.entity.content
         ).use { parser ->
             for (index in parser.list()) {

--- a/src/test/kotlin/org/opensearch/integTest/rest/ReportInstanceIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/rest/ReportInstanceIT.kt
@@ -261,10 +261,12 @@ class ReportInstanceIT : PluginRestTestCase() {
         Assert.assertEquals(totalHits, 2)
         val reportInstanceList = listReportInstancesResponse.get("reportInstanceList").asJsonArray
         Assert.assertEquals(
-            reportInstanceId, reportInstanceList[0].asJsonObject.get("id").asString
+            reportInstanceId,
+            reportInstanceList[0].asJsonObject.get("id").asString
         )
         Assert.assertEquals(
-            newReportInstanceId, reportInstanceList[1].asJsonObject.get("id").asString
+            newReportInstanceId,
+            reportInstanceList[1].asJsonObject.get("id").asString
         )
     }
 
@@ -514,10 +516,12 @@ class ReportInstanceIT : PluginRestTestCase() {
         Assert.assertEquals(totalHits, 2)
         val reportInstanceList = listReportInstancesResponse.get("reportInstanceList").asJsonArray
         Assert.assertEquals(
-            reportInstanceId, reportInstanceList[0].asJsonObject.get("id").asString
+            reportInstanceId,
+            reportInstanceList[0].asJsonObject.get("id").asString
         )
         Assert.assertEquals(
-            newReportInstanceId, reportInstanceList[1].asJsonObject.get("id").asString
+            newReportInstanceId,
+            reportInstanceList[1].asJsonObject.get("id").asString
         )
     }
 }

--- a/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesResponseTests.kt
+++ b/src/test/kotlin/org/opensearch/reportsscheduler/model/GetAllReportInstancesResponseTests.kt
@@ -16,7 +16,6 @@ import org.opensearch.reportsscheduler.getJsonString
 internal class GetAllReportInstancesResponseTests {
 
     private fun createReportInstanceSearchResults(): ReportInstanceSearchResults {
-
         return ReportInstanceSearchResults(
             startIndex = 0,
             totalHits = 100,


### PR DESCRIPTION
### Description
* Bumps `ktlint` to `0.47.1`  as per #945 
* Runs linter since there are new standards for `ktlint`

### Issues Resolved
#943 #944 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
