### PR TITLE
Updating security reachout email

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This project has adopted the [Amazon Open Source Code of Conduct](CODE_OF_CONDUC
 
 ## Security
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
+If you discover a potential security issue in this project we ask that you notify OpenSearch Security directly via email to security@opensearch.org. Please do **not** create a public GitHub issue.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 ## Reporting a Vulnerability
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/) or directly via email to aws-security@amazon.com. Please do **not** create a public GitHub issue.
+If you discover a potential security issue in this project we ask that you notify OpenSearch Security directly via email to security@opensearch.org. Please do **not** create a public GitHub issue.


### PR DESCRIPTION
### Description
Updating security reach out email address from [aws-security@amazon.com](mailto:aws-security@amazon.com) to [security@opensearch.org](mailto:security@opensearch.org).

### Issues Resolved
N/A

### Check List
- ~[ ] New functionality includes testing.~
  - ~[ ] All tests pass, including unit test, integration test and doctest~
- [x] New functionality has been documented.
  - ~[ ] New functionality has javadoc added~
  - ~[ ] New functionality has user manual doc added~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
