### PR TITLE
Register system index descriptors through SystemIndexPlugin.getSystemIndexDescriptors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,7 +329,7 @@ testClusters.integTest {
 }
 
 // For job-scheduler and reports-scheduler, the latest opensearch releases appear to be 1.1.0.0.
-String baseVersion = "2.15.0"
+String baseVersion = "2.16.0"
 String bwcVersion = baseVersion + ".0"
 String baseName = "reportsSchedulerBwcCluster"
 String bwcFilePath = "src/test/resources/bwc"

--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
@@ -40,6 +40,7 @@ import org.opensearch.reportsscheduler.action.UpdateReportInstanceStatusAction
 import org.opensearch.reportsscheduler.index.ReportDefinitionsIndex
 import org.opensearch.reportsscheduler.index.ReportDefinitionsIndex.REPORT_DEFINITIONS_INDEX_NAME
 import org.opensearch.reportsscheduler.index.ReportInstancesIndex
+import org.opensearch.reportsscheduler.index.ReportInstancesIndex.REPORT_INSTANCES_INDEX_NAME
 import org.opensearch.reportsscheduler.resthandler.OnDemandReportRestHandler
 import org.opensearch.reportsscheduler.resthandler.ReportDefinitionListRestHandler
 import org.opensearch.reportsscheduler.resthandler.ReportDefinitionRestHandler
@@ -81,7 +82,8 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
 
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
         return listOf(
-            SystemIndexDescriptor(".opendistro-reports-*", "Reports Scheduler Plugin system index pattern")
+            SystemIndexDescriptor(REPORT_DEFINITIONS_INDEX_NAME, "Reports Scheduler Plugin Definitions index"),
+            SystemIndexDescriptor(REPORT_INSTANCES_INDEX_NAME, "Reports Scheduler Plugin Instances index")
         )
     }
 

--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
@@ -81,7 +81,7 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSch
 
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
         return listOf(
-            SystemIndexDescriptor(".opendistro-reports-*", "Reports Scheduler Plugin system index pattern"),
+            SystemIndexDescriptor(".opendistro-reports-*", "Reports Scheduler Plugin system index pattern")
         )
     }
 

--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerPlugin.kt
@@ -20,11 +20,13 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.env.Environment
 import org.opensearch.env.NodeEnvironment
+import org.opensearch.indices.SystemIndexDescriptor
 import org.opensearch.jobscheduler.spi.JobSchedulerExtension
 import org.opensearch.jobscheduler.spi.ScheduledJobParser
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner
 import org.opensearch.plugins.ActionPlugin
 import org.opensearch.plugins.Plugin
+import org.opensearch.plugins.SystemIndexPlugin
 import org.opensearch.reportsscheduler.action.CreateReportDefinitionAction
 import org.opensearch.reportsscheduler.action.DeleteReportDefinitionAction
 import org.opensearch.reportsscheduler.action.GetAllReportDefinitionsAction
@@ -59,7 +61,7 @@ import java.util.function.Supplier
  * Entry point of the OpenSearch Reports scheduler plugin.
  * This class initializes the rest handlers.
  */
-class ReportsSchedulerPlugin : Plugin(), ActionPlugin, JobSchedulerExtension {
+class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSchedulerExtension {
 
     companion object {
         const val PLUGIN_NAME = "opensearch-reports-scheduler"
@@ -75,6 +77,12 @@ class ReportsSchedulerPlugin : Plugin(), ActionPlugin, JobSchedulerExtension {
         val settingList = arrayListOf<Setting<*>>()
         settingList.addAll(PluginSettings.getAllSettings())
         return settingList
+    }
+
+    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
+        return listOf(
+            SystemIndexDescriptor(".opendistro-reports-*", "Reports Scheduler Plugin system index pattern"),
+        )
     }
 
     /**

--- a/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportInstancesIndex.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportInstancesIndex.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit
  */
 internal object ReportInstancesIndex {
     private val log by logger(ReportInstancesIndex::class.java)
-    private const val REPORT_INSTANCES_INDEX_NAME = ".opendistro-reports-instances"
+    const val REPORT_INSTANCES_INDEX_NAME = ".opendistro-reports-instances"
     private const val REPORT_INSTANCES_MAPPING_FILE_NAME = "report-instances-mapping.yml"
     private const val REPORT_INSTANCES_SETTINGS_FILE_NAME = "report-instances-settings.yml"
 


### PR DESCRIPTION
### Description

This PR registers the system indices in this plugin through the SystemIndexPlugin extension point in core. These indices will not be functionally different than they are today, its just a formal registration as a system index.

### Issues Resolved

Related to: https://github.com/opensearch-project/security/issues/4439

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
  - [X] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
