### PR TITLE
Bump java to 21

### DIFF
--- a/.github/workflows/reports-scheduler-test-and-build-workflow.yml
+++ b/.github/workflows/reports-scheduler-test-and-build-workflow.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 11
-          - 17
           - 21
     runs-on: ubuntu-latest
     container:
@@ -23,6 +21,9 @@ jobs:
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
+
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
@@ -67,8 +68,6 @@ jobs:
     strategy:
       matrix:
         java:
-          - 11
-          - 17
           - 21
     runs-on: windows-latest
 
@@ -100,8 +99,7 @@ jobs:
     strategy:
       matrix:
         java:
-          - 11
-          - 17
+          - 21
     runs-on: macos-latest
 
     steps:


### PR DESCRIPTION
### Description
Bump java to 21. Adds unsecure node env to prevent build failures. 

### Issues Resolved
Fix: #1002 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
