### PR TITLE
Increase accuracy seconds while testing create on-demand report from definition

### DIFF
--- a/src/test/kotlin/org/opensearch/integTest/rest/OnDemandReportGenerationIT.kt
+++ b/src/test/kotlin/org/opensearch/integTest/rest/OnDemandReportGenerationIT.kt
@@ -81,7 +81,7 @@ class OnDemandReportGenerationIT : PluginRestTestCase() {
         validateTimeNearRefTime(
             Instant.ofEpochMilli(reportInstance.get("beginTimeMs").asLong),
             Instant.now().minus(Duration.parse(reportDefinition.get("format").asJsonObject.get("duration").asString)),
-            1
+            3
         )
         Assert.assertEquals(
             reportInstance.get("tenant").asString,


### PR DESCRIPTION
### Description
- Increased accuracy to 3 seconds to fix test create on-demand report from definition
```
Suite: Test class org.opensearch.integTest.rest.OnDemandReportGenerationIT
  2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.integTest.rest.OnDemandReportGenerationIT.test create on-demand report from definition" -Dtests.seed=ED3578B41EEBF049 -Dtests.security.manager=false -Dtests.locale=et -Dtests.timezone=Etc/UCT -Druntime.java=21
  2> java.lang.AssertionError: 2024-07-26T01:37:49.953Z + 1 > 2024-07-26T01:37:51.613507800Z
        at __randomizedtesting.SeedInfo.seed([ED3578B41EEBF049:7D2AC1B193B3B17A]:0)
        at kotlin.test.DefaultAsserter.fail(DefaultAsserter.kt:16)
        at kotlin.test.Asserter$DefaultImpls.assertTrue(Assertions.kt:652)
        at kotlin.test.DefaultAsserter.assertTrue(DefaultAsserter.kt:11)
        at kotlin.test.Asserter$DefaultImpls.assertTrue(Assertions.kt:662)
        at kotlin.test.DefaultAsserter.assertTrue(DefaultAsserter.kt:11)
        at kotlin.test.AssertionsKt__AssertionsKt.assertTrue(Assertions.kt:44)
        at kotlin.test.AssertionsKt.assertTrue(Unknown Source)
        at org.opensearch.integTest.IntegTestHelpersKt.validateTimeNearRefTime(IntegTestHelpers.kt:57)
        at org.opensearch.integTest.rest.OnDemandReportGenerationIT.test create on-demand report from definition(OnDemandReportGenerationIT.kt:81)
  2> NOTE: leaving temporary files on disk at: C:\Users\ContainerAdministrator\tmpal3owpou\opensearch-reports\build\testrun\integTest\temp\org.opensearch.integTest.rest.OnDemandReportGenerationIT_ED3578B41EEBF049-001
  2> NOTE: test params are: codec=Asserting(Lucene99): {}, docValues:{}, maxPointsInLeafNode=125, maxMBSortInHeap=6.446428262016807, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=et, timezone=Etc/UCT
  2> NOTE: Windows 10 10.0 amd64/Eclipse Adoptium 21.0.3 (64-bit)/cpus=16,threads=1,free=453955488,total=536870912
  2> NOTE: All tests run in this JVM: [InContextMenuReportGenerationIT, OnDemandReportGenerationIT]
```
Time difference in other runs 
```
java.lang.AssertionError: 2024-07-26T01:34:22.333Z + 1 > 2024-07-26T01:34:23.375386678Z
```
```
java.lang.AssertionError: 2024-07-23T01:17:37.613Z + 1 > 2024-07-23T01:17:40.377426771Z
```

Unable to reproduce this error on local so probably infra setup requires more time.

### Related Issues
Resolves https://github.com/opensearch-project/reporting/issues/1019

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
