### PR TITLE
Create the report definitions and instances indices in the system context to avoid permissions issues

### DIFF
--- a/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportDefinitionsIndex.kt
@@ -68,13 +68,15 @@ internal object ReportDefinitionsIndex {
                 .mapping(indexMappingSource, XContentType.YAML)
                 .settings(indexSettingsSource, XContentType.YAML)
             try {
-                val actionFuture = client.admin().indices().create(request)
-                val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
-                if (response.isAcknowledged) {
-                    log.info("$LOG_PREFIX:Index $REPORT_DEFINITIONS_INDEX_NAME creation Acknowledged")
-                } else {
-                    Metrics.REPORT_DEFINITION_CREATE_SYSTEM_ERROR.counter.increment()
-                    error("$LOG_PREFIX:Index $REPORT_DEFINITIONS_INDEX_NAME creation not Acknowledged")
+                client.threadPool().threadContext.stashContext().use {
+                    val actionFuture = client.admin().indices().create(request)
+                    val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+                    if (response.isAcknowledged) {
+                        log.info("$LOG_PREFIX:Index $REPORT_DEFINITIONS_INDEX_NAME creation Acknowledged")
+                    } else {
+                        Metrics.REPORT_DEFINITION_CREATE_SYSTEM_ERROR.counter.increment()
+                        error("$LOG_PREFIX:Index $REPORT_DEFINITIONS_INDEX_NAME creation not Acknowledged")
+                    }
                 }
             } catch (exception: ResourceAlreadyExistsException) {
                 log.warn("message: ${exception.message}")

--- a/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportInstancesIndex.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/index/ReportInstancesIndex.kt
@@ -68,12 +68,14 @@ internal object ReportInstancesIndex {
                 .mapping(indexMappingSource, XContentType.YAML)
                 .settings(indexSettingsSource, XContentType.YAML)
             try {
-                val actionFuture = client.admin().indices().create(request)
-                val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
-                if (response.isAcknowledged) {
-                    log.info("$LOG_PREFIX:Index $REPORT_INSTANCES_INDEX_NAME creation Acknowledged")
-                } else {
-                    error("$LOG_PREFIX:Index $REPORT_INSTANCES_INDEX_NAME creation not Acknowledged")
+                client.threadPool().threadContext.stashContext().use {
+                    val actionFuture = client.admin().indices().create(request)
+                    val response = actionFuture.actionGet(PluginSettings.operationTimeoutMs)
+                    if (response.isAcknowledged) {
+                        log.info("$LOG_PREFIX:Index $REPORT_INSTANCES_INDEX_NAME creation Acknowledged")
+                    } else {
+                        error("$LOG_PREFIX:Index $REPORT_INSTANCES_INDEX_NAME creation not Acknowledged")
+                    }
                 }
             } catch (exception: ResourceAlreadyExistsException) {
                 log.warn("message: ${exception.message}")


### PR DESCRIPTION
### Description

This PR ensures that the report definitions and instances system indices can be created regardless if the authenticated user has permission to create the indices upon first first definition indexed or first report instance indexed.

### Related Issues
Resolves https://github.com/opensearch-project/reporting/issues/998

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/reporting/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
