### PR TITLE
Declare report-instance as child resource of report-definition

### DIFF
--- a/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerExtension.kt
+++ b/src/main/kotlin/org/opensearch/reportsscheduler/ReportsSchedulerExtension.kt
@@ -24,8 +24,23 @@ class ReportsSchedulerExtension : ResourceSharingExtension {
             object : ResourceProvider {
                 override fun resourceType(): String = Utils.REPORT_INSTANCE_TYPE
                 override fun resourceIndexName(): String = ReportInstancesIndex.REPORT_INSTANCES_INDEX_NAME
+
+                // Report instances are child resources of the report definition
+                // they were generated from: access is inherited from the parent
+                // definition's sharing record. This also covers instances created
+                // without an authenticated user in context (on-demand runs under
+                // the plugin subject; scheduled runs under job-scheduler).
+                override fun parentType(): String = Utils.REPORT_DEFINITION_TYPE
+                override fun parentIdField(): String = PARENT_ID_FIELD
             }
         )
+    }
+
+    companion object {
+        // Flattened field in the report instance document that holds the id of
+        // the report definition it was generated from. Indexed as keyword in
+        // report-instances-mapping.yml.
+        private const val PARENT_ID_FIELD = "reportDefinitionDetails.id"
     }
 
     override fun assignResourceSharingClient(resourceSharingClient: ResourceSharingClient?) {


### PR DESCRIPTION
### Description
Declares `parentType`/`parentIdField` on the `report-instance` resource provider so report instances inherit access from the report definition they were generated from — whoever can access a definition can access its generated reports. The parent id is extracted from the flattened `reportDefinitionDetails.id` field, already indexed as keyword in `report-instances-mapping.yml`.

Why this is needed:
- **Scheduled report instances** are indexed by jobs running under job-scheduler with no authenticated user in the thread context; the security plugin cannot attribute a sharing entry to them. With this change + opensearch-project/security#6373, those instances receive parent-linked entries inheriting the definition owner's access.
- **Semantics**: instances have no independent access model — they are outputs of their definition. Child declaration makes evaluation delegate to the definition's shares natively.

Context: the resource-sharing onboarding (#1141, 2025-12-10) predates parent/child support in the SPI (security#5735, 2026-03-23), so this wiring could not be added at onboarding time and was never retrofitted.

### Investigation note (correction)
An earlier version of this description claimed on-demand instances are indexed under the plugin subject and receive no sharing entries. That was traced to listener-attachment timing on a 3.8.0 snapshot instead (type added to `protected_types` dynamically after the instances index was already open — no listener until restart). On-demand writes do carry the user and receive entries once the listener is attached; the child declaration remains necessary for scheduled instances and for correct inheritance semantics.

### Depends on
opensearch-project/security#6373 (parent-linked entries for user-less writes; integration-tested there)

### Category
Bug fix

### Testing
- `compileKotlin` passes; field name verified against the index mapping
- Child→parent inheritance semantics covered by security#6373 integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
